### PR TITLE
Add market studies theme option

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
             <option>Organisation achats</option>
             <option>Maturité digitale / IA</option>
             <option>Gouvernance & Data</option>
+            <option>Études de marché</option>
             <option>PMO & exécution</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- add an "Études de marché" option to the theme selector so the menu covers market studies requests

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d8059a1ec48326b4a5dac116dbc4e7