### PR TITLE
Add mini diagnostic workflow and API support

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,28 @@
     .ok{ color:var(--ok); font-weight:600; }
     .spinner{ display:inline-block; width:16px; height:16px; border:2px solid #9fb4ff; border-top-color:transparent; border-radius:50%; animation:spin 0.8s linear infinite; vertical-align:-3px; }
     @keyframes spin{ to{ transform:rotate(360deg);} }
+    .hidden{ display:none !important; }
+    button.secondary{ background:transparent; border-color:#2a3a66; color:var(--muted); }
+    button.secondary:hover{ border-color:var(--accent); color:var(--text); }
+    .diagnostic{ margin-top:24px; background:#0d1730; border:1px solid #223760; border-radius:16px; padding:18px 20px; }
+    .diagnostic h3{ margin:0 0 4px 0; font-size:17px; }
+    .diagnostic .muted{ margin-top:4px; }
+    .diagnostic-expectations{ margin:12px 0 0; padding-left:18px; line-height:1.5; }
+    .diagnostic-expectations.hidden{ display:none; }
+    .diagnostic-form fieldset{ border:1px solid #1f2f55; border-radius:14px; padding:12px 16px; margin:16px 0 0; }
+    .diagnostic-form legend{ font-weight:600; padding:0 6px; }
+    .diagnostic-form .question-description{ margin:6px 0 0; color:var(--muted); font-size:14px; }
+    .diagnostic-form .question-options{ display:flex; flex-direction:column; gap:8px; margin-top:10px; }
+    .diagnostic-form .option-pill{ display:flex; align-items:center; gap:10px; padding:10px 12px; border:1px solid #223760; border-radius:10px; background:#0b1730; cursor:pointer; transition:border-color .2s, background .2s; }
+    .diagnostic-form .option-pill:hover{ border-color:var(--accent); background:#101c3a; }
+    .diagnostic-form .option-pill input{ accent-color:var(--accent); }
+    .diagnostic-form textarea{ min-height:80px; margin-top:10px; }
+    .diagnostic-actions{ margin-top:18px; }
+    .diagnostic-summary{ margin-top:18px; background:#081123; border:1px solid #1a2747; border-radius:14px; padding:16px; }
+    .diagnostic-summary.hidden{ display:none; }
+    .diagnostic-summary h3, .diagnostic-summary h4{ margin-top:0; }
+    .diagnostic-summary ul{ padding-left:18px; margin:10px 0; }
+    .diagnostic-summary p{ margin:10px 0; }
   </style>
 </head>
 <body>
@@ -94,6 +116,22 @@
           <button id="startMini" class="primary">Lancer un mini-diagnostic (5–6 questions)</button>
           <button id="downloadPdf">Télécharger en PDF</button>
         </div>
+        <div id="diagnosticPanel" class="diagnostic hidden">
+          <div class="diagnostic-header">
+            <h3>Mini-diagnostic IA</h3>
+            <p id="diagnosticIntro" class="muted">Répondez à ces questions pour obtenir un diagnostic rapide (5–6 questions).</p>
+            <ul id="diagnosticExpectations" class="diagnostic-expectations hidden"></ul>
+          </div>
+          <div id="diagnosticStatus" class="muted"></div>
+          <div id="diagnosticError" class="error" role="alert" aria-live="assertive"></div>
+          <form id="diagnosticForm" class="diagnostic-form" novalidate></form>
+          <div class="row diagnostic-actions">
+            <button id="diagnosticSubmit" class="primary" type="submit" form="diagnosticForm">Analyser mes réponses</button>
+            <button id="diagnosticCancel" type="button" class="secondary">Fermer</button>
+            <button id="diagnosticRestart" type="button" class="secondary hidden">Recommencer</button>
+          </div>
+          <section id="diagnosticSummary" class="diagnostic-summary hidden" aria-live="polite"></section>
+        </div>
       </div>
     </div>
   </main>
@@ -102,7 +140,25 @@
   </footer>
 
   <script>
-    const API_BASE = "https://poc-consulting.netlify.app/.netlify/functions"; // ← remplace par ton URL
+    const inferApiBase = () => {
+      if (window.POC_API_BASE) {
+        return String(window.POC_API_BASE).replace(/\/$/, "");
+      }
+      const meta = document.querySelector('meta[name="poc-api-base"]');
+      if (meta?.content) {
+        return meta.content.replace(/\/$/, "");
+      }
+      const { origin, protocol, hostname } = window.location;
+      if (protocol === "file:") {
+        return "";
+      }
+      if (["localhost", "127.0.0.1"].includes(hostname)) {
+        return "http://localhost:8888/.netlify/functions";
+      }
+      return `${origin.replace(/\/$/, "")}/.netlify/functions`;
+    };
+
+    const API_BASE = inferApiBase();
     const runBtn = document.getElementById("runBtn");
     const needEl = document.getElementById("need");
     const themeEl = document.getElementById("theme");
@@ -114,7 +170,20 @@
     const nextEl = document.getElementById("next");
     const detectedEl = document.getElementById("detected");
     const modelUsedEl = document.getElementById("modelUsed");
+    const startMiniBtn = document.getElementById("startMini");
+    const diagnosticPanel = document.getElementById("diagnosticPanel");
+    const diagnosticIntroEl = document.getElementById("diagnosticIntro");
+    const diagnosticExpectationsEl = document.getElementById("diagnosticExpectations");
+    const diagnosticStatusEl = document.getElementById("diagnosticStatus");
+    const diagnosticErrorEl = document.getElementById("diagnosticError");
+    const diagnosticForm = document.getElementById("diagnosticForm");
+    const diagnosticSubmitBtn = document.getElementById("diagnosticSubmit");
+    const diagnosticCancelBtn = document.getElementById("diagnosticCancel");
+    const diagnosticRestartBtn = document.getElementById("diagnosticRestart");
+    const diagnosticSummaryEl = document.getElementById("diagnosticSummary");
     modelUsedEl.style.display = "none";
+
+    const DEFAULT_DIAGNOSTIC_INTRO = "Répondez aux questions pour obtenir un diagnostic rapide.";
 
     const friendlyError = (code, details = {}) => Object.assign(new Error(code), { code, ...details });
 
@@ -133,14 +202,302 @@
       if (err?.code === "NETWORK_ERROR") {
         return "Impossible de contacter l'API. Vérifie l'URL, la connexion réseau ou les autorisations CORS.";
       }
+      if (err?.code === "VALIDATION_ERROR") {
+        return err?.message || "Veuillez vérifier les informations saisies.";
+      }
       return err?.message || "Une erreur inattendue est survenue.";
     };
 
     const ensureApiConfigured = () => {
-      if (!API_BASE || API_BASE.includes("YOUR-NETLIFY")) {
+      if (!API_BASE || /YOUR-NETLIFY|REPLACE|EXAMPLE/i.test(API_BASE)) {
         throw friendlyError("API_BASE_NOT_CONFIGURED");
       }
     };
+
+    const postJson = async (endpoint, payload) => {
+      try {
+        ensureApiConfigured();
+        const res = await fetch(endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) {
+          const body = await res.text().catch(() => "");
+          throw friendlyError("HTTP_ERROR", { status: `${res.status} ${res.statusText}`.trim(), body });
+        }
+        try {
+          return await res.json();
+        } catch (parseErr) {
+          throw friendlyError("BAD_JSON");
+        }
+      } catch (err) {
+        if (!err.code && err.name === "TypeError") {
+          err.code = "NETWORK_ERROR";
+        }
+        throw err;
+      }
+    };
+
+    const renderMarkdown = (text = "") => {
+      if (!text) return "";
+      const lines = String(text).split(/\r?\n/);
+      const html = [];
+      let inList = false;
+      const closeList = () => {
+        if (inList) {
+          html.push("</ul>");
+          inList = false;
+        }
+      };
+      for (const line of lines) {
+        if (/^\s*[-*]\s+/.test(line)) {
+          if (!inList) {
+            html.push("<ul>");
+            inList = true;
+          }
+          html.push(`<li>${line.replace(/^\s*[-*]\s+/, "")}</li>`);
+          continue;
+        }
+        closeList();
+        if (/^###\s+/.test(line)) {
+          html.push(`<h3>${line.replace(/^###\s+/, "")}</h3>`);
+        } else if (/^##\s+/.test(line)) {
+          html.push(`<h2>${line.replace(/^##\s+/, "")}</h2>`);
+        } else if (/^#\s+/.test(line)) {
+          html.push(`<h1>${line.replace(/^#\s+/, "")}</h1>`);
+        } else if (line.trim() === "") {
+          html.push("");
+        } else {
+          html.push(`<p>${line}</p>`);
+        }
+      }
+      closeList();
+      return html.join("");
+    };
+
+    const resetDiagnosticView = ({ keepPanel = false } = {}) => {
+      diagnosticForm.reset?.();
+      diagnosticForm.innerHTML = "";
+      diagnosticStatusEl.textContent = "";
+      diagnosticErrorEl.textContent = "";
+      diagnosticSummaryEl.innerHTML = "";
+      diagnosticSummaryEl.classList.add("hidden");
+      diagnosticSubmitBtn.disabled = false;
+      diagnosticSubmitBtn.textContent = "Analyser mes réponses";
+      diagnosticRestartBtn.classList.add("hidden");
+      diagnosticIntroEl.textContent = DEFAULT_DIAGNOSTIC_INTRO;
+      diagnosticExpectationsEl.innerHTML = "";
+      diagnosticExpectationsEl.classList.add("hidden");
+      if (!keepPanel) {
+        diagnosticPanel.classList.add("hidden");
+      }
+    };
+
+    const updateDiagnosticExpectations = (items) => {
+      if (!Array.isArray(items) || !items.length) {
+        diagnosticExpectationsEl.innerHTML = "";
+        diagnosticExpectationsEl.classList.add("hidden");
+        return;
+      }
+      diagnosticExpectationsEl.classList.remove("hidden");
+      diagnosticExpectationsEl.innerHTML = items
+        .map((item) => {
+          const title = item?.title ? `<strong>${item.title}</strong>` : "";
+          const desc = item?.description ? ` — ${item.description}` : "";
+          return `<li>${title}${desc}</li>`;
+        })
+        .join("");
+    };
+
+    const questionFieldName = (question, index) => {
+      return `diag-${String(question?.id ?? index).replace(/[^a-z0-9_-]/gi, '-')}`;
+    };
+
+    const renderDiagnosticQuestions = (questions = []) => {
+      diagnosticForm.innerHTML = "";
+      if (!Array.isArray(questions) || !questions.length) {
+        diagnosticStatusEl.textContent = "Impossible de préparer le mini-diagnostic pour le moment.";
+        diagnosticSubmitBtn.disabled = true;
+        return;
+      }
+      const fragment = document.createDocumentFragment();
+      questions.forEach((question, index) => {
+        const fieldset = document.createElement("fieldset");
+        const legend = document.createElement("legend");
+        legend.textContent = `${index + 1}. ${question?.title || "Question"}`;
+        fieldset.appendChild(legend);
+        if (question?.description) {
+          const desc = document.createElement("p");
+          desc.className = "question-description";
+          desc.textContent = question.description;
+          fieldset.appendChild(desc);
+        }
+        const optionsContainer = document.createElement("div");
+        optionsContainer.className = "question-options";
+        const fieldName = questionFieldName(question, index);
+        if (Array.isArray(question?.options)) {
+          question.options.forEach((option, optIndex) => {
+            const optionId = `${fieldName}-${optIndex}`;
+            const label = document.createElement("label");
+            label.className = "option-pill";
+            label.setAttribute("for", optionId);
+            const input = document.createElement("input");
+            input.type = "radio";
+            input.name = fieldName;
+            input.id = optionId;
+            input.value = option?.value ?? String(optIndex);
+            if (option?.label) {
+              input.dataset.label = option.label;
+            }
+            label.appendChild(input);
+            const span = document.createElement("span");
+            span.textContent = option?.label || option?.value || `Option ${optIndex + 1}`;
+            label.appendChild(span);
+            if (option?.hint) {
+              const hint = document.createElement("small");
+              hint.className = "muted";
+              hint.textContent = option.hint;
+              label.appendChild(hint);
+            }
+            optionsContainer.appendChild(label);
+          });
+        }
+        fieldset.appendChild(optionsContainer);
+        if (question?.allowComment) {
+          const comment = document.createElement("textarea");
+          comment.name = `${fieldName}-comment`;
+          comment.placeholder = question?.commentLabel || "Précisions (optionnel)";
+          fieldset.appendChild(comment);
+        }
+        fragment.appendChild(fieldset);
+      });
+      diagnosticForm.appendChild(fragment);
+      diagnosticSubmitBtn.disabled = false;
+      diagnosticStatusEl.textContent = "Répondez à chaque question puis lancez l'analyse.";
+    };
+
+    const diagnosticState = {
+      questions: [],
+      systemInstruction: "",
+      analysisInstruction: ""
+    };
+
+    let diagnosticLoading = false;
+
+    const callDiagnostic = (payload) => postJson(`${API_BASE}/diagnostic`, payload);
+
+    const beginDiagnosticFlow = async () => {
+      if (diagnosticLoading) return;
+      const need = needEl.value.trim();
+      if (!need) {
+        alert("Merci de décrire le besoin avant de lancer le mini-diagnostic.");
+        return;
+      }
+      diagnosticLoading = true;
+      diagnosticPanel.classList.remove("hidden");
+      resetDiagnosticView({ keepPanel: true });
+      diagnosticSubmitBtn.disabled = true;
+      diagnosticStatusEl.innerHTML = '<span class="spinner"></span> Préparation du mini-diagnostic…';
+      try {
+        const data = await callDiagnostic({
+          action: "generate",
+          need,
+          theme: themeEl.value,
+          tone: toneEl.value,
+          modelKey: modelEl.value
+        });
+        diagnosticState.questions = Array.isArray(data?.questions) ? data.questions : [];
+        diagnosticState.systemInstruction = data?.systemInstruction || "";
+        diagnosticState.analysisInstruction = data?.analysisInstruction || "";
+        diagnosticIntroEl.textContent = data?.intro || DEFAULT_DIAGNOSTIC_INTRO;
+        updateDiagnosticExpectations(data?.analysisExpectations);
+        renderDiagnosticQuestions(diagnosticState.questions);
+        diagnosticStatusEl.innerHTML = diagnosticState.questions.length
+          ? "Répondez à chaque question puis lancez l'analyse."
+          : "Aucune question n'a pu être générée.";
+        diagnosticSubmitBtn.disabled = !diagnosticState.questions.length;
+      } catch (err) {
+        console.error(err);
+        diagnosticStatusEl.textContent = "";
+        diagnosticErrorEl.textContent = formatErrorMessage(err);
+      } finally {
+        diagnosticLoading = false;
+      }
+    };
+
+    const collectDiagnosticAnswers = () => {
+      if (!diagnosticState.questions.length) {
+        throw friendlyError("VALIDATION_ERROR", { message: "Le mini-diagnostic n'est pas prêt." });
+      }
+      const answers = diagnosticState.questions.map((question, index) => {
+        const name = questionFieldName(question, index);
+        const selected = diagnosticForm.querySelector(`input[name="${name}"]:checked`);
+        const commentEl = diagnosticForm.querySelector(`[name="${name}-comment"]`);
+        return {
+          id: question?.id || String(index),
+          title: question.title || `Question ${index + 1}`,
+          value: selected?.value || "",
+          label: selected?.dataset?.label || selected?.value || "",
+          comment: commentEl?.value?.trim() || ""
+        };
+      });
+      const missing = answers.filter((answer) => !answer.value);
+      if (missing.length) {
+        const firstMissing = missing[0]?.title || "question";
+        throw friendlyError("VALIDATION_ERROR", { message: `Merci de sélectionner une réponse pour « ${firstMissing} ».` });
+      }
+      return answers;
+    };
+
+    diagnosticForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      try {
+        const answers = collectDiagnosticAnswers();
+        diagnosticErrorEl.textContent = "";
+        diagnosticSummaryEl.classList.add("hidden");
+        diagnosticSummaryEl.innerHTML = "";
+        diagnosticSubmitBtn.disabled = true;
+        diagnosticSubmitBtn.innerHTML = '<span class="spinner"></span> Analyse en cours…';
+        diagnosticStatusEl.innerHTML = '<span class="spinner"></span> Analyse des réponses…';
+        const data = await callDiagnostic({
+          action: "analyze",
+          need: needEl.value.trim(),
+          theme: themeEl.value,
+          tone: toneEl.value,
+          modelKey: modelEl.value,
+          answers,
+          questions: diagnosticState.questions,
+          systemInstruction: diagnosticState.systemInstruction,
+          analysisInstruction: diagnosticState.analysisInstruction
+        });
+        const html = data?.resultHtml || renderMarkdown(data?.result || data?.analysis || "");
+        diagnosticSummaryEl.innerHTML = html || "<p>Aucune analyse n'a été renvoyée.</p>";
+        diagnosticSummaryEl.classList.remove("hidden");
+        diagnosticStatusEl.innerHTML = '<span class="ok">Analyse du mini-diagnostic disponible.</span>';
+        diagnosticSubmitBtn.textContent = "Analyser de nouveau";
+        diagnosticSubmitBtn.disabled = false;
+        diagnosticRestartBtn.classList.remove("hidden");
+      } catch (err) {
+        console.error(err);
+        diagnosticSubmitBtn.disabled = false;
+        diagnosticSubmitBtn.textContent = "Analyser mes réponses";
+        diagnosticStatusEl.textContent = "";
+        diagnosticErrorEl.textContent = formatErrorMessage(err);
+      }
+    });
+
+    diagnosticCancelBtn.addEventListener("click", () => {
+      resetDiagnosticView();
+    });
+
+    diagnosticRestartBtn.addEventListener("click", () => {
+      beginDiagnosticFlow();
+    });
+
+    startMiniBtn.addEventListener("click", () => {
+      beginDiagnosticFlow();
+    });
 
     runBtn.addEventListener("click", async () => {
       const need = needEl.value.trim();
@@ -150,27 +507,12 @@
       statusEl.innerHTML = '<span class="spinner"></span> Analyse en cours…';
 
       try {
-        ensureApiConfigured();
-        const res = await fetch(`${API_BASE}/analyze-need`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            need,
-            theme: themeEl.value,
-            tone: toneEl.value,
-            modelKey: modelEl.value
-          })
+        const data = await postJson(`${API_BASE}/analyze-need`, {
+          need,
+          theme: themeEl.value,
+          tone: toneEl.value,
+          modelKey: modelEl.value
         });
-        if (!res.ok) {
-          const body = await res.text().catch(() => "");
-          throw friendlyError("HTTP_ERROR", { status: `${res.status} ${res.statusText}`.trim(), body });
-        }
-        let data;
-        try {
-          data = await res.json();
-        } catch (parseErr) {
-          throw friendlyError("BAD_JSON");
-        }
 
         detectedEl.textContent = data.detectedTheme ? `Cadre: ${data.detectedTheme}` : "Cadre: (auto)";
         modelUsedEl.textContent = data.modelUsed ? `Modèle: ${data.modelUsed}` : "";
@@ -180,12 +522,8 @@
 
         resultEl.style.display = "block";
         statusEl.innerHTML = '<span class="ok">Proposition générée.</span>';
-      } catch (e) {
-        console.error(e);
-        const err = e instanceof Error ? e : new Error(String(e));
-        if (!err.code && err.name === "TypeError") {
-          err.code = "NETWORK_ERROR";
-        }
+      } catch (err) {
+        console.error(err);
         resultEl.style.display = "none";
         modelUsedEl.textContent = "";
         modelUsedEl.style.display = "none";
@@ -195,12 +533,7 @@
       }
     });
 
-    document.getElementById("startMini").addEventListener("click", () => {
-      alert("Mini-diagnostic à venir (5–6 questions). POC : bouton factice pour l’instant.");
-    });
-
     document.getElementById("downloadPdf").addEventListener("click", () => {
-      // Version simple : invite l’utilisateur à imprimer en PDF (Ctrl/Cmd+P)
       window.print();
     });
   </script>

--- a/netlify/functions/diagnostic.js
+++ b/netlify/functions/diagnostic.js
@@ -1,5 +1,5 @@
 // Netlify Function — diagnostic (Gemini)
-// Fournit deux actions: analyze (diagnostic complet) et synthesize (résumé court)
+// Fournit trois actions: generate (questions), analyze (diagnostic complet) et synthesize (résumé court)
 
 function cors() {
   return {
@@ -11,6 +11,100 @@ function cors() {
 }
 
 const DEFAULT_MODEL = "models/gemini-1.5-flash";
+
+const QUESTION_BANK = [
+  {
+    id: "vision",
+    title: "Vision & sponsoring",
+    description: "Clarté de l'objectif et niveau d'engagement des décideurs.",
+    allowComment: true,
+    commentLabel: "Contexte supplémentaire (optionnel)",
+    options: [
+      { value: "flou", label: "Vision peu formalisée ou sponsor absent" },
+      { value: "partiel", label: "Objectifs en cours de cadrage, sponsor identifié" },
+      { value: "aligne", label: "Vision partagée, sponsor engagé et disponible" }
+    ]
+  },
+  {
+    id: "data",
+    title: "Données disponibles",
+    description: "Qualité, accès et gouvernance des données utiles.",
+    allowComment: true,
+    options: [
+      { value: "disperse", label: "Données dispersées ou peu fiables" },
+      { value: "partielle", label: "Sources identifiées mais hétérogènes" },
+      { value: "qualifiee", label: "Base consolidée avec gouvernance active" }
+    ]
+  },
+  {
+    id: "process",
+    title: "Processus & exécution",
+    description: "Niveau de formalisation des processus impactés par l'IA.",
+    allowComment: true,
+    options: [
+      { value: "ad-hoc", label: "Processus peu formalisés / dépendants des individus" },
+      { value: "structure", label: "Processus documentés mais perfectibles" },
+      { value: "industrialise", label: "Processus maîtrisés avec indicateurs suivis" }
+    ]
+  },
+  {
+    id: "skills",
+    title: "Compétences & équipes",
+    description: "Disponibilité des compétences data/IA et conduite du changement.",
+    allowComment: true,
+    options: [
+      { value: "limite", label: "Compétences internes limitées" },
+      { value: "mixte", label: "Équipe mixte interne/externe" },
+      { value: "autonome", label: "Équipe dédiée expérimentée" }
+    ]
+  },
+  {
+    id: "governance",
+    title: "Gouvernance & priorisation",
+    description: "Cadre de décision, priorisation des cas d'usage et pilotage.",
+    allowComment: true,
+    options: [
+      { value: "informel", label: "Décisions opportunistes, gouvernance absente" },
+      { value: "emergent", label: "Instances ponctuelles, priorisation partielle" },
+      { value: "cadre", label: "Gouvernance claire, arbitrages réguliers" }
+    ]
+  },
+  {
+    id: "impact",
+    title: "Mesure d'impact",
+    description: "Suivi des bénéfices et diffusion des résultats.",
+    allowComment: true,
+    options: [
+      { value: "aucun", label: "Peu ou pas d'indicateurs suivis" },
+      { value: "partiel", label: "Indicateurs définis mais usage irrégulier" },
+      { value: "suivi", label: "KPIs partagés et suivis régulièrement" }
+    ]
+  }
+];
+
+const DEFAULT_INTRO = "Répondez à ce mini-questionnaire pour situer rapidement votre maturité data / IA.";
+const DEFAULT_EXPECTATIONS = [
+  { title: "Synthèse", description: "1 à 2 phrases qui résument la situation." },
+  { title: "Points forts", description: "Ce qui peut être valorisé immédiatement." },
+  { title: "Risques / alertes", description: "Points de vigilance à adresser." },
+  { title: "Recommandations rapides", description: "3 à 5 actions concrètes sur 30 jours." }
+];
+
+const DEFAULT_SYSTEM_INSTRUCTION = `Tu es directeur de mission en cabinet de conseil.
+Tu réalises des diagnostics flash de maturité IA.
+Tu es factuel, clair, orienté plan d'action.`;
+
+const DEFAULT_ANALYSIS_INSTRUCTION = `Analyse les réponses au mini-diagnostic ci-dessous.
+Retourne un texte structuré en Markdown avec :
+### Synthèse
+- 2 phrases maximum
+### Points forts
+- Liste de puces
+### Risques / alertes
+- Liste de puces
+### Recommandations rapides
+- Liste de puces avec actions concrètes (30-60 jours).
+Adapte le ton au format demandé (consulting, executive, detailed).`;
 
 const ensureString = (value) => {
   if (typeof value === "string") return value;
@@ -48,6 +142,42 @@ const callGemini = async ({ userPrompt, systemInstruction, model }) => {
   return response.json();
 };
 
+const markdownToHtml = (text) => {
+  const lines = ensureString(text).split(/\r?\n/);
+  const chunks = [];
+  let inList = false;
+  const closeList = () => {
+    if (inList) {
+      chunks.push("</ul>");
+      inList = false;
+    }
+  };
+  for (const line of lines) {
+    if (/^\s*[-*]\s+/.test(line)) {
+      if (!inList) {
+        chunks.push("<ul>");
+        inList = true;
+      }
+      chunks.push(`<li>${line.replace(/^\s*[-*]\s+/, "")}</li>`);
+      continue;
+    }
+    closeList();
+    if (/^###\s+/.test(line)) {
+      chunks.push(`<h3>${line.replace(/^###\s+/, "")}</h3>`);
+    } else if (/^##\s+/.test(line)) {
+      chunks.push(`<h2>${line.replace(/^##\s+/, "")}</h2>`);
+    } else if (/^#\s+/.test(line)) {
+      chunks.push(`<h1>${line.replace(/^#\s+/, "")}</h1>`);
+    } else if (line.trim() === "") {
+      chunks.push("");
+    } else {
+      chunks.push(`<p>${line}</p>`);
+    }
+  }
+  closeList();
+  return chunks.join("");
+};
+
 exports.handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: cors(), body: "ok" };
@@ -71,9 +201,30 @@ exports.handler = async (event) => {
     systemInstruction,
     synthesisSystemInstruction,
     model,
+    need = "",
+    theme = "",
+    tone = "",
+    answers = [],
+    questions,
+    analysisInstruction,
   } = payload;
 
   try {
+    if (action === "generate") {
+      return {
+        statusCode: 200,
+        headers: cors(),
+        body: JSON.stringify({
+          action,
+          intro: DEFAULT_INTRO,
+          analysisExpectations: DEFAULT_EXPECTATIONS,
+          questions: QUESTION_BANK,
+          systemInstruction: ensureString(systemInstruction) || DEFAULT_SYSTEM_INSTRUCTION,
+          analysisInstruction: ensureString(analysisInstruction) || DEFAULT_ANALYSIS_INSTRUCTION,
+        }),
+      };
+    }
+
     if (action === "synthesize") {
       const synthData = await callGemini({
         userPrompt: synthesisPrompt || prompt,
@@ -96,9 +247,39 @@ exports.handler = async (event) => {
       };
     }
 
+    const effectiveQuestions = Array.isArray(questions) && questions.length ? questions : QUESTION_BANK;
+    const normalizedAnswers = Array.isArray(answers) ? answers : [];
+    const answerMap = new Map();
+    normalizedAnswers.forEach((entry, index) => {
+      const id = entry?.id ?? String(index);
+      answerMap.set(id, {
+        value: ensureString(entry?.value),
+        label: ensureString(entry?.label || entry?.value),
+        comment: ensureString(entry?.comment),
+      });
+    });
+
+    const answerLines = effectiveQuestions.map((question, index) => {
+      const id = question?.id ?? String(index);
+      const stored = answerMap.get(id) || {};
+      const title = ensureString(question?.title || `Question ${index + 1}`);
+      const label = stored.label || "(non renseigné)";
+      const base = `${index + 1}. ${title} : ${label}`;
+      return stored.comment ? `${base} | Commentaire : ${stored.comment}` : base;
+    }).join("\n");
+
+    const instructionText = ensureString(analysisInstruction) || ensureString(prompt) || DEFAULT_ANALYSIS_INSTRUCTION;
+    const analysisPrompt = instructionText
+      + "\n\nContexte client :\n"
+      + `${ensureString(need) || "(non communiqué)"}\n`
+      + `Thème / cadre : ${ensureString(theme) || "Auto-détection"}\n`
+      + `Format attendu : ${ensureString(tone) || "consulting"}\n\n`
+      + "Réponses du mini-diagnostic :\n"
+      + answerLines;
+
     const analyzeData = await callGemini({
-      userPrompt: prompt,
-      systemInstruction,
+      userPrompt: analysisPrompt,
+      systemInstruction: ensureString(systemInstruction) || DEFAULT_SYSTEM_INSTRUCTION,
       model,
     });
     const analyzeParts = analyzeData?.candidates?.[0]?.content?.parts;
@@ -113,6 +294,7 @@ exports.handler = async (event) => {
       body: JSON.stringify({
         action: "analyze",
         result: safeAnalyze,
+        resultHtml: markdownToHtml(safeAnalyze),
       }),
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- add front-end autodetection for the API base URL and introduce the mini-diagnostic form with generate/analyze handling
- extend the diagnostic Netlify function with a reusable question bank plus formatted analysis responses for the UI

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de827c83248326afaf4c649781468b