### PR TITLE
Clean up analyze-need Netlify function import and response handling

### DIFF
--- a/netlify/functions/analyze-need.js
+++ b/netlify/functions/analyze-need.js
@@ -1,14 +1,9 @@
-const { resolveModel, cors, mdToHtml, partsToText } = require("./_shared/helpers");
+const { cors, resolveModel, mdToHtml, partsToText } = require("./_shared/gemini");
 
 // Netlify Function — analyze-need (Gemini) avec sélection de modèle
 // Env requises: GEMINI_API_KEY (et optionnel: DEFAULT_GEMINI_MODEL)
 // Appel: POST JSON { need, theme, tone, modelKey?: "simple|balanced|pro|max", modelId?: "models/..." }
 
-codex/clean-up-conflict-sections-and-remove-old-implementations
-const { cors, resolveModel, mdToHtml, partsToText } = require("./_shared/gemini");
-
-=======
-main
 exports.handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: cors(), body: "ok" };
@@ -20,6 +15,7 @@ exports.handler = async (event) => {
 
   try {
     const { need, theme, tone, modelKey, modelId } = JSON.parse(event.body || "{}");
+
     if (!need || typeof need !== "string") {
       return { statusCode: 400, headers: cors(), body: JSON.stringify({ error: "Missing 'need' string" }) };
     }
@@ -27,7 +23,7 @@ exports.handler = async (event) => {
     const selectedModel = resolveModel({ modelKey, modelId });
 
     const themes = ["Organisation achats", "Maturité digitale / IA", "Gouvernance & Data", "PMO & exécution"];
-    const detected = theme && theme.trim() ? theme.trim() : "";
+    const detectedThemeInput = theme && theme.trim() ? theme.trim() : "";
 
     const systemInstruction = `
 Tu es un directeur de mission en cabinet de conseil.
@@ -39,7 +35,7 @@ style concis, professionnel, lisible. Reste factuel et actionnable.`;
 BESOIN CLIENT:
 ${need}
 
-THEME PREFERE (optionnel): ${detected || "(auto-détection parmi: " + themes.join(", ") + ")"}
+THEME PREFERE (optionnel): ${detectedThemeInput || "(auto-détection parmi: " + themes.join(", ") + ")"}
 FORMAT: ${tone || "consulting"}
 
 CADRES DISPONIBLES:
@@ -69,7 +65,7 @@ EXIGENCE DE SORTIE (structure exacte):
 
     const url = `https://generativelanguage.googleapis.com/v1beta/${selectedModel}:generateContent?key=${process.env.GEMINI_API_KEY}`;
 
-    const r = await fetch(url, {
+    const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -79,16 +75,17 @@ EXIGENCE DE SORTIE (structure exacte):
       }),
     });
 
-    if (!r.ok) {
-      const errtxt = await r.text();
+    if (!response.ok) {
+      const detail = await response.text();
       return {
         statusCode: 502,
         headers: cors(),
-        body: JSON.stringify({ error: "Gemini error", detail: errtxt, model: selectedModel }),
+        body: JSON.stringify({ error: "Gemini error", detail, model: selectedModel }),
       };
     }
 
-codex/clean-up-conflict-sections-and-remove-old-implementations
+    const data = await response.json();
+
     if (!Array.isArray(data?.candidates) || data.candidates.length === 0) {
       return {
         statusCode: 502,
@@ -97,37 +94,34 @@ codex/clean-up-conflict-sections-and-remove-old-implementations
       };
     }
 
-    const parts = data.candidates[0]?.content?.parts;
-    const raw = partsToText(parts);
-    if (!raw.trim()) {
+    const parts = data.candidates[0]?.content?.parts ?? [];
+    const rawText = partsToText(parts);
+    const text = typeof rawText === "string" ? rawText : String(rawText ?? "");
+
+    if (!text.trim()) {
       return {
         statusCode: 502,
         headers: cors(),
         body: JSON.stringify({ error: "Empty response", model: selectedModel }),
       };
     }
-    const text = partsToText(parts);
-=======
-    const data = await r.json();
-    const parts = data?.candidates?.[0]?.content?.parts;
-    const rawText = partsToText(parts);
-    const text = typeof rawText === "string" ? rawText : String(rawText ?? "");
-main
 
-    const block = (label) => {
+    const extractBlock = (label) => {
       const rx = new RegExp(`### ${label}:[\\s\\S]*?(?=\\n###|$)`, "i");
-      const m = text.match(rx);
-      return m ? m[0].replace(new RegExp(`^### ${label}:\\s*`, "i"), "").trim() : "";
+      const match = text.match(rx);
+      return match ? match[0].replace(new RegExp(`^### ${label}:\\s*`, "i"), "").trim() : "";
     };
 
-    const cadreLine = text.match(/### Cadre retenu:\s*([^\n]+)/i)?.[1]?.trim() || detected || "";
-    const approach = [
-      "### Objectifs:\n" + block("Objectifs"),
-      "### Méthodologie:\n" + block("Méthodologie"),
-      "### Livrables:\n" + block("Livrables"),
-      "### Planning indicatif:\n" + block("Planning indicatif"),
-    ].join("\n\n");
-    const nextSteps = block("Prochaines étapes");
+    const cadreLine = text.match(/### Cadre retenu:\s*([^\n]+)/i)?.[1]?.trim() || detectedThemeInput || "";
+
+    const buildSection = (label) => {
+      const content = extractBlock(label);
+      return content ? `### ${label}:\n${content}` : "";
+    };
+
+    const approachSections = ["Objectifs", "Méthodologie", "Livrables", "Planning indicatif"].map(buildSection).filter(Boolean);
+    const approach = approachSections.join("\n\n");
+    const nextSteps = extractBlock("Prochaines étapes");
 
     return {
       statusCode: 200,
@@ -141,11 +135,11 @@ main
         nextStepsHtml: mdToHtml(nextSteps),
       }),
     };
-  } catch (e) {
+  } catch (error) {
     return {
       statusCode: 500,
       headers: cors(),
-      body: JSON.stringify({ error: "Server error", detail: String(e?.message || e) }),
+      body: JSON.stringify({ error: "Server error", detail: String(error?.message || error) }),
     };
   }
 };


### PR DESCRIPTION
## Summary
- remove leftover merge-conflict markers and rely on the shared Gemini helper utilities
- parse the Gemini response JSON a single time before validating and building the final payload
- rebuild the approach/next-steps extraction helpers to avoid empty sections and provide consistent HTML

## Testing
- `GEMINI_API_KEY=dummy netlify functions:serve` *(required to host the function locally for invocation)*
- `GEMINI_API_KEY=dummy netlify functions:invoke analyze-need --port 9999 --payload '{"need":"Optimiser notre supply chain","theme":"Organisation achats"}'` *(fails: fetch failed because no outbound network access/valid Gemini API key)*

------
https://chatgpt.com/codex/tasks/task_e_68dea276d688832697d558025130489d