### PR TITLE
Expand mini diagnostic to ten questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,13 +113,13 @@
           <div id="next"></div>
         </section>
         <div class="row" style="margin-top:12px;">
-          <button id="startMini" class="primary">Lancer un mini-diagnostic (5–6 questions)</button>
+          <button id="startMini" class="primary">Lancer un mini-diagnostic (10 questions)</button>
           <button id="downloadPdf">Télécharger en PDF</button>
         </div>
         <div id="diagnosticPanel" class="diagnostic hidden">
           <div class="diagnostic-header">
             <h3>Mini-diagnostic IA</h3>
-            <p id="diagnosticIntro" class="muted">Répondez à ces questions pour obtenir un diagnostic rapide (5–6 questions).</p>
+            <p id="diagnosticIntro" class="muted">Répondez à ces questions pour obtenir un diagnostic rapide (10 questions).</p>
             <ul id="diagnosticExpectations" class="diagnostic-expectations hidden"></ul>
           </div>
           <div id="diagnosticStatus" class="muted"></div>

--- a/netlify/functions/diagnostic.js
+++ b/netlify/functions/diagnostic.js
@@ -72,6 +72,50 @@ const QUESTION_BANK = [
       { value: "partiel", label: "Indicateurs définis mais usage irrégulier" },
       { value: "suivi", label: "KPIs partagés et suivis régulièrement" }
     ]
+  },
+  {
+    id: "infrastructure",
+    title: "Infrastructure & outils",
+    description: "Disponibilité des plateformes data / IA et intégration au SI.",
+    allowComment: true,
+    options: [
+      { value: "fragmentee", label: "Outils disparates, intégrations limitées" },
+      { value: "en-transition", label: "Socle en cours de modernisation" },
+      { value: "industrialisee", label: "Plateforme robuste, intégrée et scalable" }
+    ]
+  },
+  {
+    id: "securite",
+    title: "Sécurité & conformité",
+    description: "Cadre de gestion des risques, conformité et protection des données.",
+    allowComment: true,
+    options: [
+      { value: "non-cadre", label: "Peu de contrôles formalisés" },
+      { value: "partiel", label: "Politique définie mais application hétérogène" },
+      { value: "maitrise", label: "Cadre robuste, contrôles réguliers et documentés" }
+    ]
+  },
+  {
+    id: "culture",
+    title: "Culture & adoption",
+    description: "Appétence des équipes métiers pour les usages data / IA.",
+    allowComment: true,
+    options: [
+      { value: "sceptique", label: "Résistances fortes, usages isolés" },
+      { value: "exploration", label: "Initiatives pilotes, intérêt grandissant" },
+      { value: "diffusee", label: "Culture data partagée, initiatives multipliées" }
+    ]
+  },
+  {
+    id: "ecosysteme",
+    title: "Partenariats & écosystème",
+    description: "Mobilisation d'experts externes et d'un réseau d'innovation.",
+    allowComment: true,
+    options: [
+      { value: "limite", label: "Peu de partenaires identifiés" },
+      { value: "opportuniste", label: "Recours ponctuel à des partenaires" },
+      { value: "structure", label: "Écosystème établi avec collaborations régulières" }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- extend the diagnostic function question bank to ten topics covering infrastructure, sécurité, culture et écosystème pour des retours plus complets
- mettre à jour les libellés du mini-diagnostic côté front pour annoncer 10 questions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea29169488326bfddb12ab3e7b3af