### PR TITLE
Add Études de marché theme to analyze-need prompt

### DIFF
--- a/netlify/functions/analyze-need.js
+++ b/netlify/functions/analyze-need.js
@@ -22,7 +22,13 @@ exports.handler = async (event) => {
 
     const selectedModel = resolveModel({ modelKey, modelId });
 
-    const themes = ["Organisation achats", "Maturité digitale / IA", "Gouvernance & Data", "PMO & exécution"];
+    const themes = [
+      "Organisation achats",
+      "Maturité digitale / IA",
+      "Gouvernance & Data",
+      "PMO & exécution",
+      "Études de marché",
+    ];
     const detectedThemeInput = theme && theme.trim() ? theme.trim() : "";
 
     const systemInstruction = `
@@ -43,6 +49,7 @@ CADRES DISPONIBLES:
 - Maturité digitale / IA
 - Gouvernance & Data
 - PMO & exécution
+- Études de marché
 
 EXIGENCE DE SORTIE (structure exacte):
 ### Cadre retenu:


### PR DESCRIPTION
## Summary
- add the "Études de marché" option to the Gemini theme list in analyze-need
- ensure the CADRES DISPONIBLES section includes the same option so the prompt matches the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea7203cec8326b8e60cf0e61e3092